### PR TITLE
Qs v4: Unvollständige Daten für den 16.04.2020

### DIFF
--- a/qs-actions.sh
+++ b/qs-actions.sh
@@ -62,8 +62,8 @@ echo "carriage return entfernt"
 find . -name "$files" -exec sed -i -E 's#([0-9]{2})\.([0-9]{2})\.([0-9]{4})#\3/\2/\1#g' {} \;
 find . -name "$files" -exec sed -i -E 's# 00\:00\:00\+00##g' {} \;
 find . -name "$files" -exec sed -i -E 's#T00\:00\:00\.000Z##g' {} \;
-find . -name "$files" -exec sed -i -E 's# 00\:00(\:00){0,1}##g' {} \;
 find . -name "$files" -exec sed -i -E 's#, [0-9]{2}\:[0-9]{2} Uhr##g' {} \;
+find . -name "$files" -exec sed -i -E 's# 00\:00(\:00){0,1}##g' {} \;
 find . -name "$files" -exec sed -i -E 's#([0-9]{1,2})\/([0-9]{1,2})\/([0-9]{4})#\3/\2/\1#g' {} \;
 find . -name "$files" -exec sed -i -E 's#([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{4})#\3/\2/\1#g' {} \;
 find . -name "$files" -exec sed -i -E 's#([0-9]{4})\-([0-9]{1,2})\-([0-9]{1,2})#\1/\2/\3#g' {} \;


### PR DESCRIPTION
Hallo Charles,

bei der Analyse aller CSV-Dateien ist mir aufgefallen, dass die CSV vom 16.04.2020 unvollständig ist.

Es muss immer gelten:

Fälle_gesamt_heute = Fälle_gesamt_gestern + Fälle_neu_heute

Für den 16.04.2020 im Vergleich zum Vortag trifft das nicht zu und es gibt eine Differenz. Ich habe die Datei von ARD runtergeladen, bereinigt und ersetzt. Nun tritt der Fehler nicht mehr auf. In der ARD-Datei musste ich unter anderem für das Feld Refdatum Timestamp durch Date ersetzen. Totales Datentypen-Chaos....

Daneben kleine Verbessung am Bash-Skript.

VG,

Christian